### PR TITLE
Custom spaceports.

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -644,10 +644,10 @@ interface "planet"
 		align left
 		pad 10 0
 	
-	visible if "has spaceport"
+	visible if "has port"
 	sprite "ui/planet dialog button"
 		center -400 270
-	button p "Space_port"
+	"dynamic button" p "port name"
 		center -400 270
 		dimensions 140 40
 		size 18

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -111,7 +111,8 @@ void Interface::Load(const DataNode &node)
 			// Check if this node specifies a known element type.
 			if(child.Token(0) == "sprite" || child.Token(0) == "image" || child.Token(0) == "outline")
 				elements.push_back(new ImageElement(child, anchor));
-			else if(child.Token(0) == "label" || child.Token(0) == "string" || child.Token(0) == "button")
+			else if(child.Token(0) == "label" || child.Token(0) == "string" || child.Token(0) == "button"
+					|| child.Token(0) == "dynamic button")
 				elements.push_back(new TextElement(child, anchor));
 			else if(child.Token(0) == "bar" || child.Token(0) == "ring")
 				elements.push_back(new BarElement(child, anchor));
@@ -480,8 +481,8 @@ Interface::TextElement::TextElement(const DataNode &node, const Point &globalAnc
 	if(node.Size() < 2)
 		return;
 	
-	isDynamic = (node.Token(0) == "string");
-	if(node.Token(0) == "button")
+	isDynamic = (node.Token(0) == "string" || node.Token(0) == "dynamic button");
+	if(node.Token(0) == "button" || node.Token(0) == "dynamic button")
 	{
 		buttonKey = node.Token(1).front();
 		if(node.Size() >= 3)

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -98,8 +98,8 @@ void Planet::Load(const DataNode &node)
 				attributes.clear();
 			else if(key == "description")
 				description.clear();
-			else if(key == "spaceport")
-				spaceport.clear();
+			else if(key == "spaceport" || key == "port")
+				port = Port();
 			else if(key == "shipyard")
 				shipSales.clear();
 			else if(key == "outfitter")
@@ -163,7 +163,15 @@ void Planet::Load(const DataNode &node)
 			music = value;
 		else if(key == "description" || key == "spaceport")
 		{
-			string &text = (key == "description") ? description : spaceport;
+			const bool isDescription = key == "description";
+			if(!isDescription)
+			{
+				port.name = "Spaceport";
+				port.recharge = Port::All;
+				port.hasNews = true;
+			}
+
+			string &text = isDescription ? description : port.description;
 			if(!text.empty() && !value.empty() && value[0] > ' ')
 				text += '\t';
 			text += value;
@@ -210,12 +218,39 @@ void Planet::Load(const DataNode &node)
 					grand.PrintTrace("Skipping unrecognized tribute attribute:");
 			}
 		}
+		else if(key == "port")
+		{
+			port.name = value;
+			for(const auto &grand : child)
+			{
+				if(grand.Token(0) == "shields")
+					port.recharge = static_cast<Port::RechargeType>(port.recharge | Port::Shields);
+				else if(grand.Token(0) == "hull")
+					port.recharge = static_cast<Port::RechargeType>(port.recharge | Port::Hull);
+				else if(grand.Token(0) == "energy")
+					port.recharge = static_cast<Port::RechargeType>(port.recharge | Port::Energy);
+				else if(grand.Token(0) == "fuel")
+					port.recharge = static_cast<Port::RechargeType>(port.recharge | Port::Fuel);
+				else if(grand.Token(0) == "news")
+					port.hasNews = true;
+				else if(grand.Token(0) == "description" && grand.Size() >= 2)
+				{
+					const auto &value = grand.Token(1);
+					if(!port.description.empty() && !value.empty() && value[0] > ' ')
+						port.description += '\t';
+					port.description += value;
+					port.description += '\n';
+				}
+				else
+					grand.PrintTrace("Skipping unrecognized attribute:");
+			}
+		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
 	
 	static const vector<string> AUTO_ATTRIBUTES = {"spaceport", "shipyard", "outfitter"};
-	bool autoValues[3] = {!spaceport.empty(), !shipSales.empty(), !outfitSales.empty()};
+	bool autoValues[3] = {port.name == "Spaceport", !shipSales.empty(), !outfitSales.empty()};
 	for(unsigned i = 0; i < AUTO_ATTRIBUTES.size(); ++i)
 	{
 		if(autoValues[i])
@@ -319,15 +354,23 @@ const string &Planet::Noun() const
 // jobs, banking, and hiring).
 bool Planet::HasSpaceport() const
 {
-	return !spaceport.empty();
+	return port.name == "Spaceport";
 }
 
 
 
-// Get the spaceport's descriptive text.
-const string &Planet::SpaceportDescription() const
+// Check whether there is a port (which may even be a full spaceport).
+bool Planet::HasPort() const
 {
-	return spaceport;
+	return !port.name.empty();
+}
+
+
+
+// Get this planet's port. Might be empty if there is no port.
+const Planet::Port &Planet::GetPort() const
+{
+	return port;
 }
 
 

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -38,6 +38,36 @@ class System;
 // might choose it as a source or destination.
 class Planet {
 public:
+	class Port
+	{
+	public:
+		// The different properties that can be recharged by a port.
+		enum RechargeType
+		{
+			None = 0x0,
+			Shields = 0x1,
+			Hull = 0x2,
+			Energy = 0x4,
+			Fuel = 0x8,
+			All = Shields | Hull | Energy | Fuel,
+		};
+	public:
+		// The name of this port.
+		std::string name;
+
+		// The description of this port. Shown when clicking on the
+		// port button on the planet panel.
+		std::string description;
+
+		// What is recharged when landing on this port.
+		RechargeType recharge = None;
+
+		// Whether this port has news.
+		bool hasNews = false;
+	};
+
+
+public:
 	// Load a planet's description from a file.
 	void Load(const DataNode &node);
 	// Check if both this planet and its containing system(s) have been defined.
@@ -67,8 +97,10 @@ public:
 	// Check whether there is a spaceport (which implies there is also trading,
 	// jobs, banking, and hiring).
 	bool HasSpaceport() const;
-	// Get the spaceport's descriptive text.
-	const std::string &SpaceportDescription() const;
+	// Check whether there is a port (which may even be a full spaceport).
+	bool HasPort() const;
+	// Get this planet's port. Might be empty if there is no port.
+	const Port &GetPort() const;
 	
 	// Check if this planet is inhabited (i.e. it has a spaceport, and does not
 	// have the "uninhabited" attribute).
@@ -139,7 +171,7 @@ private:
 	bool isDefined = false;
 	std::string name;
 	std::string description;
-	std::string spaceport;
+	Port port;
 	const Sprite *landscape = nullptr;
 	std::string music;
 	

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -115,8 +115,11 @@ void PlanetPanel::Draw()
 			}
 		}
 		
-		if(flagship && planet.HasSpaceport())
-			info.SetCondition("has spaceport");
+		if(flagship && planet.HasPort())
+		{
+			info.SetCondition("has port");
+			info.SetString("port name", planet.GetPort().name);
+		}
 		
 		if(planet.HasShipyard())
 			info.SetCondition("has shipyard");
@@ -162,7 +165,7 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 		selectedPanel = bank.get();
 		GetUI()->Push(bank);
 	}
-	else if(key == 'p' && hasAccess && flagship && planet.HasSpaceport())
+	else if(key == 'p' && hasAccess && flagship && planet.HasPort())
 	{
 		selectedPanel = spaceport.get();
 		if(isNewPress)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1162,13 +1162,13 @@ void PlayerInfo::Land(UI *ui)
 		{
 			if(ship->GetSystem() == system)
 			{
-				ship->Recharge(hasSpaceport);
+				ship->Recharge(hasSpaceport ? Planet::Port::All : Planet::Port::None);
 				ship->Cargo().TransferAll(cargo);
 				if(!ship->GetPlanet())
 					ship->SetPlanet(planet);
 			}
 			else
-				ship->Recharge(false);
+				ship->Recharge(Planet::Port::None);
 		}
 	// Adjust cargo cost basis for any cargo lost due to a ship being destroyed.
 	for(const auto &it : lostCargo)
@@ -1295,11 +1295,11 @@ bool PlayerInfo::TakeOff(UI *ui)
 		{
 			if(ship->GetSystem() != system)
 			{
-				ship->Recharge(false);
+				ship->Recharge(Planet::Port::None);
 				continue;
 			}
 			else
-				ship->Recharge(hasSpaceport);
+				ship->Recharge(hasSpaceport ? Planet::Port::All : Planet::Port::None);
 			
 			if(ship != flagship)
 			{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -684,7 +684,7 @@ void Ship::FinishLoading(bool isNewInstance)
 	// If this ship is being instantiated for the first time, make sure its
 	// crew, fuel, etc. are all refilled.
 	if(isNewInstance)
-		Recharge(true);
+		Recharge();
 	
 	// Ensure that all defined bays are of a valid category. Remove and warn about any
 	// invalid bays. Add a default "launch effect" to any remaining internal bays if
@@ -2719,7 +2719,7 @@ void Ship::Restore()
 	explosionCount = 0;
 	explosionRate = 0;
 	UnmarkForRemoval();
-	Recharge(true);
+	Recharge();
 }
 
 
@@ -2733,30 +2733,24 @@ bool Ship::IsDestroyed() const
 
 
 // Recharge and repair this ship (e.g. because it has landed).
-void Ship::Recharge(bool atSpaceport)
+void Ship::Recharge(Planet::Port::RechargeType rechargeType)
 {
 	if(IsDestroyed())
 		return;
 	
-	if(atSpaceport)
+	if(rechargeType == Planet::Port::All)
 		crew = min<int>(max(crew, RequiredCrew()), attributes.Get("bunks"));
 	pilotError = 0;
 	pilotOkay = 0;
 	
-	if(atSpaceport || attributes.Get("shield generation"))
+	if((rechargeType & Planet::Port::Shields) || attributes.Get("shield generation"))
 		shields = attributes.Get("shields");
-	if(atSpaceport || attributes.Get("hull repair rate"))
+	if((rechargeType & Planet::Port::Hull) || attributes.Get("hull repair rate"))
 		hull = attributes.Get("hull");
-	if(atSpaceport || attributes.Get("energy generation"))
+	if((rechargeType & Planet::Port::Energy) || attributes.Get("energy generation"))
 		energy = attributes.Get("energy capacity");
-	if(atSpaceport || attributes.Get("fuel generation"))
+	if((rechargeType & Planet::Port::Fuel) || attributes.Get("fuel generation"))
 		fuel = attributes.Get("fuel capacity");
-	if(GetPlanet())
-	{
-		const auto planetAttrs = GetPlanet()->Attributes();
-		if(planetAttrs.find("fuel cache") != planetAttrs.end() || atSpaceport)
-			fuel = attributes.Get("fuel capacity");
-	}
 	
 	heat = IdleHeat();
 	ionization = 0.;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -21,6 +21,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Command.h"
 #include "EsUuid.h"
 #include "Outfit.h"
+#include "Planet.h"
 #include "Personality.h"
 #include "Point.h"
 
@@ -38,7 +39,6 @@ class Flotsam;
 class Government;
 class Minable;
 class Phrase;
-class Planet;
 class PlayerInfo;
 class Projectile;
 class StellarObject;
@@ -264,7 +264,7 @@ public:
 	// Check if this ship has been destroyed.
 	bool IsDestroyed() const;
 	// Recharge and repair this ship (e.g. because it has landed).
-	void Recharge(bool atSpaceport = true);
+	void Recharge(Planet::Port::RechargeType rechargeType = Planet::Port::All);
 	// Check if this ship is able to give the given ship enough fuel to jump.
 	bool CanRefuel(const Ship &other) const;
 	// Give the other ship enough fuel for it to jump.

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -29,14 +29,14 @@ using namespace std;
 
 
 SpaceportPanel::SpaceportPanel(PlayerInfo &player)
-	: player(player)
+	: player(player), port(player.GetPlanet()->GetPort())
 {
 	SetTrapAllEvents(false);
 	
 	text.SetFont(FontSet::Get(14));
 	text.SetAlignment(Alignment::JUSTIFIED);
 	text.SetWrapWidth(480);
-	text.Wrap(player.GetPlanet()->SpaceportDescription());
+	text.Wrap(port.description);
 	
 	// Query the news interface to find out the wrap width.
 	// TODO: Allow Interface to handle wrapped text directly.
@@ -110,6 +110,9 @@ void SpaceportPanel::Draw()
 // If there is no applicable news, this returns null.
 const News *SpaceportPanel::PickNews() const
 {
+	if(!port.hasNews)
+		return nullptr;
+
 	vector<const News *> matches;
 	const Planet *planet = player.GetPlanet();
 	const map<string, int64_t> &conditions = player.Conditions();

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -14,6 +14,7 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #define SPACEPORT_PANEL_H_
 
 #include "Panel.h"
+#include "Planet.h"
 
 #include "Information.h"
 #include "text/WrappedText.h"
@@ -42,6 +43,7 @@ private:
 private:
 	PlayerInfo &player;
 	WrappedText text;
+	const Planet::Port &port;
 	
 	// Current news item (if any):
 	bool hasNews = false;


### PR DESCRIPTION
## Feature Details

Adds the ability to custom define a partial spaceport.

## Usage Examples

```
port <name>                # The name shown on the button.
    shields                # Whether the port recharges your shields.
    hull                   # Whether the port repairs your hull.
    energy                 # Whether the port recharges your energy.
    fuel                   # Whether the port refuels your ships.
    news                   # Whether news are shown.
    "description" <text>   # The description shown in the center.
```

If the name is `Spaceport` then it is a special port (the spaceport) where you can hire people, have access to the bank, ....